### PR TITLE
arreglo de bug subida de archivos (backend)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Voluntariado
 
-nosejkdsgdlgfdavshfahdjchdkjdaskdsad
+## Davidshtp es David Alexis Medina Trujillo
+## FelipeFajardo1 es Felipe Fajardo Castro
+## Neonwaac es Jose Manuel Pantoja
+## FAgCSec es Edwin Fabian Agudelo


### PR DESCRIPTION
# Descripción
Se arreglo el bug que no dejaba subir archivos a una persona que recién iba a subir su primer archivo de verificación si ya existían archivos pasados subidos por otros usuarios.
Se detecto que el error era que se estaba pasando una verificación temporal para primero verificar los archivos si pasaban las verificaciones se subía a la bd, pero en ese caso la verificación temporal no tenia id.verificacion pq es undefined porque no existía en la base de datos por lo tanto la jQuery que validaba si ya tenia archivos subidos traía los archivos de verificación de las otras personas y nos daba el error de que ya había subido ese archivo.

la solución fue manejar ese posible caso en el helper de validar subida de los archivos.

## Fixes #81 

### Screenshots or Videos
<img width="858" height="192" alt="image" src="https://github.com/user-attachments/assets/5ffcb5fe-f953-44e0-b366-0edb6f3296b9" />
