### PR TITLE
Creación Entidad Comentarios_Voluntariado

### DIFF
--- a/backend/nest-app/src/app.module.ts
+++ b/backend/nest-app/src/app.module.ts
@@ -23,6 +23,7 @@ import { NotificacionesModule } from './notificaciones/notificaciones.module';
 import { FotosVoluntariadoModule } from './fotos_voluntariado/fotos_voluntariado.module';
 import { UbicacionModule } from './ubicacion/ubicacion.module';
 import { InscripcionModule } from './inscripcion/inscripcion.module';
+import { ComentariosVoluntariadoModule } from './comentarios_voluntariado/comentarios_voluntariado.module';
 
 
 @Module({
@@ -66,7 +67,8 @@ import { InscripcionModule } from './inscripcion/inscripcion.module';
     NotificacionesModule,
     FotosVoluntariadoModule,
     UbicacionModule,
-    InscripcionModule
+    InscripcionModule,
+    ComentariosVoluntariadoModule
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/nest-app/src/comentarios_voluntariado/comentarios_voluntariado.controller.ts
+++ b/backend/nest-app/src/comentarios_voluntariado/comentarios_voluntariado.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Post, Get, Body } from '@nestjs/common';
+import { ComentariosVoluntariadoService } from './comentarios_voluntariado.service';
+import { CreateComentarioVoluntariadoDto } from './dto/create-comentario_voluntariado.dto';
+@Controller('comentarios-voluntariado')
+export class ComentariosVoluntariadoController {
+  constructor(private readonly service: ComentariosVoluntariadoService) {}
+
+  @Post()
+  async crearComentario(@Body() dto: CreateComentarioVoluntariadoDto) {
+    return this.service.crearComentario(dto);
+  }
+
+  @Get()
+  async listarComentarios() {
+    return this.service.listarComentarios();
+  }
+}

--- a/backend/nest-app/src/comentarios_voluntariado/comentarios_voluntariado.module.ts
+++ b/backend/nest-app/src/comentarios_voluntariado/comentarios_voluntariado.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ComentariosVoluntariado } from './entity/comentarios_voluntariado.entity';
+import { ComentariosVoluntariadoService } from './comentarios_voluntariado.service';
+import { ComentariosVoluntariadoController } from './comentarios_voluntariado.controller';
+import { Inscripcion } from '../inscripcion/entity/inscripcion.entity';
+import { Voluntariado } from '../voluntariado/entity/voluntariado.entity';
+import { Usuario } from 'src/usuario/entity/usuario.entity';
+
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ComentariosVoluntariado, Inscripcion, Voluntariado, Usuario])],
+  controllers: [ComentariosVoluntariadoController],
+  providers: [ComentariosVoluntariadoService],
+})
+export class ComentariosVoluntariadoModule {}

--- a/backend/nest-app/src/comentarios_voluntariado/comentarios_voluntariado.service.ts
+++ b/backend/nest-app/src/comentarios_voluntariado/comentarios_voluntariado.service.ts
@@ -1,0 +1,108 @@
+import {
+  Injectable,
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ComentariosVoluntariado } from './entity/comentarios_voluntariado.entity';
+import { CreateComentarioVoluntariadoDto } from './dto/create-comentario_voluntariado.dto';
+import { Voluntariado } from 'src/voluntariado/entity/voluntariado.entity';
+import { Inscripcion, EstadoInscripcion } from 'src/inscripcion/entity/inscripcion.entity';
+import { Usuario, RolUsuario } from 'src/usuario/entity/usuario.entity';
+
+@Injectable()
+export class ComentariosVoluntariadoService {
+  constructor(
+    @InjectRepository(ComentariosVoluntariado)
+    private comentarioRepo: Repository<ComentariosVoluntariado>,
+
+    @InjectRepository(Voluntariado)
+    private voluntariadoRepo: Repository<Voluntariado>,
+
+    @InjectRepository(Inscripcion)
+    private inscripcionRepo: Repository<Inscripcion>,
+
+    @InjectRepository(Usuario)
+    private usuarioRepo: Repository<Usuario>,
+  ) { }
+
+  async crearComentario(dto: CreateComentarioVoluntariadoDto) {
+    const { voluntario_id, creador_id, calificacion, comentario, voluntariado_id } = dto;
+
+    //  Buscar voluntario y creador
+    const [voluntario, creador] = await Promise.all([
+      this.usuarioRepo.findOne({ where: { id_usuario: voluntario_id } }),
+      this.usuarioRepo.findOne({ where: { id_usuario: creador_id } }),
+    ]);
+
+    if (!voluntario) throw new NotFoundException('Voluntario no encontrado');
+    if (!creador) throw new NotFoundException('Creador no encontrado');
+
+    if (voluntario.rol !== RolUsuario.VOLUNTARIO)
+      throw new ForbiddenException('Solo los voluntarios pueden calificar voluntariados.');
+
+    //  Buscar voluntariado
+    const voluntariado = await this.voluntariadoRepo.findOne({
+      where: { id_voluntariado: voluntariado_id },
+      relations: ['creador'],
+    });
+
+    if (!voluntariado) throw new NotFoundException('Voluntariado no encontrado');
+    if (voluntariado.estado !== 'terminado')
+      throw new BadRequestException('Solo se pueden calificar voluntariados terminados.');
+
+    // Buscar inscripción válida
+    const inscripcion = await this.inscripcionRepo.findOne({
+      where: {
+        voluntario: { id_usuario: voluntario_id },
+        voluntariado: { id_voluntariado: voluntariado.id_voluntariado },
+        estado_inscripcion: EstadoInscripcion.ACEPTADA,
+      },
+    });
+
+    if (!inscripcion)
+      throw new ForbiddenException('No puedes calificar este voluntariado, no estás inscrito.');
+
+    //  Verificar asistencia obligatoria
+    if (!inscripcion.asistencia)
+      throw new ForbiddenException('Solo puedes calificar si asististe al voluntariado.');
+
+    // Verificar comentario previo
+    const comentarioExistente = await this.comentarioRepo.findOne({
+      where: {
+        voluntario: { id_usuario: voluntario_id },
+        voluntariado: { id_voluntariado: voluntariado.id_voluntariado },
+      },
+    });
+
+    if (comentarioExistente)
+      throw new BadRequestException('Ya has calificado este voluntariado.');
+
+    //  Crear comentario y guardar
+    const nuevoComentario = this.comentarioRepo.create({
+      voluntario,
+      creador,
+      voluntariado,
+      comentario,
+      calificacion,
+    });
+
+    const guardado = await this.comentarioRepo.save(nuevoComentario);
+
+    //  Actualizar el campo calificado = true en la inscripción
+    inscripcion.calificado = true;
+    await this.inscripcionRepo.save(inscripcion);
+
+    return guardado;
+  }
+
+
+  async listarComentarios() {
+    return this.comentarioRepo.find({
+      relations: ['voluntario', 'creador'],
+      order: { id_comentario: 'DESC' },
+    });
+  }
+}

--- a/backend/nest-app/src/comentarios_voluntariado/dto/create-comentario_voluntariado.dto.ts
+++ b/backend/nest-app/src/comentarios_voluntariado/dto/create-comentario_voluntariado.dto.ts
@@ -1,0 +1,32 @@
+import {
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+export class CreateComentarioVoluntariadoDto {
+  @IsInt({ message: 'El ID del voluntario debe ser un número entero.' })
+  @IsNotEmpty({ message: 'El campo "voluntario_id" es obligatorio.' })
+  voluntario_id: number;
+
+  @IsInt({ message: 'El ID del creador debe ser un número entero.' })
+  @IsNotEmpty({ message: 'El campo "creador_id" es obligatorio.' })
+  creador_id: number;
+
+  @IsInt({ message: 'El ID del voluntariado debe ser un número entero.' })
+  @IsNotEmpty({ message: 'El campo "voluntariado_id" es obligatorio.' })
+  voluntariado_id: number;
+
+  @IsOptional()
+  @IsString({ message: 'El comentario debe ser un texto válido.' })
+  comentario?: string;
+
+  @IsInt({ message: 'La calificación debe ser un número entero.' })
+  @Min(1, { message: 'La calificación mínima permitida es 1.' })
+  @Max(5, { message: 'La calificación máxima permitida es 5.' })
+  @IsNotEmpty({ message: 'La calificación es obligatoria.' })
+  calificacion: number;
+}

--- a/backend/nest-app/src/comentarios_voluntariado/entity/comentarios_voluntariado.entity.ts
+++ b/backend/nest-app/src/comentarios_voluntariado/entity/comentarios_voluntariado.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+} from 'typeorm';
+import { Usuario } from 'src/usuario/entity/usuario.entity';
+import { Voluntariado } from 'src/voluntariado/entity/voluntariado.entity';
+
+@Entity('comentarios_voluntariado')
+export class ComentariosVoluntariado {
+  @PrimaryGeneratedColumn({ type: 'bigint', unsigned: true })
+  id_comentario: number;
+
+  // 🔹 Usuario que hace el comentario (voluntario)
+  @ManyToOne(() => Usuario, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'voluntario_id' })
+  voluntario: Usuario;
+
+  // 🔹 Usuario creador del voluntariado
+  @ManyToOne(() => Usuario, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'creador_id' })
+  creador: Usuario;
+
+  // 🔹 Voluntariado asociado
+  @ManyToOne(() => Voluntariado, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'id_voluntariado' })
+  voluntariado: Voluntariado;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  comentario: string;
+
+  @Column({ type: 'tinyint', unsigned: true })
+  calificacion: number; // Valor de 1 a 5
+
+  @CreateDateColumn({ name: 'fecha_creacion' })
+  fecha_creacion: Date;
+}


### PR DESCRIPTION
# Descripción
Se implementó una nueva entidad llamada comentarios_voluntariado que permite a los voluntarios dejar una calificación y un comentario sobre un voluntariado una vez que este se encuentra en estado "terminado" y el voluntario haya asistido al evento.

Tareas realizadas
1. Creación de la entidad comentarios_voluntariado
2. Creación del DTO CreateComentarioVoluntariadoDto
3. Creación del service ComentariosVoluntariadoService
4. Restricciones aplicadas
Solo los usuarios con rol VOLUNTARIO pueden comentar.
Un voluntario solo puede dejar un comentario por voluntariado.
La asistencia al evento es obligatoria para poder comentar.
5. Relaciones
comentarios_voluntariado se relaciona con:
usuario (como voluntario y creador).
voluntariado.
inscripcion (para actualización del estado de calificación).

# Fixes #161 

# ScreenShots / Videos

<img width="1010" height="756" alt="{944EE223-9B1A-4174-A58A-76223E1B33AB}" src="https://github.com/user-attachments/assets/c2ed0108-eb22-4d4d-847e-5e5a29eb46fa" />
<img width="926" height="797" alt="{C17393A2-2617-4EB6-BCCC-FDB7A551861B}" src="https://github.com/user-attachments/assets/c93df6ab-22cb-40c3-915a-03927162e147" />
