### PR TITLE
Implementar paginación y separación de lógica voluntariados en HomeVo…

### DIFF
--- a/backend/nest-app/copy-db.js
+++ b/backend/nest-app/copy-db.js
@@ -1,6 +1,5 @@
-// copy-db.js
-import fs from "fs";
-import path from "path";
+const fs = require("fs");
+const path = require("path");
 
 const src = path.join("src", "database", "colombia");
 const dest = path.join("dist", "database", "colombia");

--- a/frontend/src/components/Map/VolunteeringMap/VolunteeringMap.jsx
+++ b/frontend/src/components/Map/VolunteeringMap/VolunteeringMap.jsx
@@ -11,9 +11,9 @@ const token = process.env.REACT_APP_MAPBOX_TOKEN;
 
 const VolunteeringMap = ({ volunteerings, mapApiRef }) => {
   const [viewState, setViewState] = useState({
-    longitude: -76.648213,
-    latitude: 1.1465863,
-    zoom: 14,
+    longitude: -76.6465421,
+    latitude: 1.1491254,
+    zoom: 17,
   });
   const [hovered, setHovered] = useState(null);
   const [selected, setSelected] = useState(null);

--- a/frontend/src/components/Map/VolunteeringMapModal/VolunteeringMapModal.css
+++ b/frontend/src/components/Map/VolunteeringMapModal/VolunteeringMapModal.css
@@ -153,6 +153,12 @@
   box-shadow: 0 2px 8px rgba(139, 92, 246, 0.3);
 }
 
+.volunteering-map-modal-status.status-available {
+  background: linear-gradient(135deg, #007AFF 0%, #0051D5 100%);
+  color: white;
+  box-shadow: 0 2px 8px rgba(0, 122, 255, 0.35);
+}
+
 .volunteering-map-modal-body {
   padding: 2rem;
   display: flex;

--- a/frontend/src/components/VolunteeringCard/VolunteeringCard.css
+++ b/frontend/src/components/VolunteeringCard/VolunteeringCard.css
@@ -125,6 +125,12 @@
   box-shadow: 0 2px 8px rgba(239, 68, 68, 0.3);
 }
 
+.volunteering-card-status-available {
+  background: linear-gradient(135deg, var(--color-primary, #007aff) 0%, #0051d5 100%);
+  color: white;
+  box-shadow: 0 2px 8px rgba(0, 122, 255, 0.3);
+}
+
 .volunteering-card-description {
   font-size: 0.95rem;
   color: #525252;
@@ -460,6 +466,9 @@
   }
 
   .volunteering-card-location-btn {
+    width: 100%;
+  }
+  .volunteering-card-inscribe-btn {
     width: 100%;
   }
 }

--- a/frontend/src/components/VolunteeringCard/VolunteeringCard.jsx
+++ b/frontend/src/components/VolunteeringCard/VolunteeringCard.jsx
@@ -1,6 +1,10 @@
 // ...existing code...
 import React, { useEffect, useRef, useState } from "react";
-import "./VolunteeringCard.css"
+import "./VolunteeringCard.css";
+import ConfirmAlert from "../alerts/ConfirmAlert";
+import { InscribeIntoVolunteering } from "../../services/volunteering/VolunteeringService";
+import Swal from "sweetalert2";
+import { SuccessAlert, WrongAlert } from "../../utils/ToastAlerts";
 
 function VolunteeringCard({ volunteering, onFocusMap }) {
   const {
@@ -15,96 +19,135 @@ function VolunteeringCard({ volunteering, onFocusMap }) {
     fotos = [],
     ubicacion,
     inscripciones,
-    participantesAceptados
-  } = volunteering
+    participantesAceptados,
+  } = volunteering;
 
-  const nombreEntidad = creador?.creador?.nombre_entidad
+  const [inscribing, setInscribing] = useState(false);
+  const nombreEntidad = creador?.creador?.nombre_entidad;
+
+  const handleInscribe = async () => {
+    if (!volunteering?.id_voluntariado || inscribing) return;
+    const confirmed = await ConfirmAlert({
+      title: "Inscribirte",
+      message: "¿Deseas inscribirte a este voluntariado?",
+      confirmText: "Sí, inscribirme",
+      cancelText: "Cancelar",
+    });
+    if (!confirmed) return;
+    try {
+      setInscribing(true);
+      const resp = await InscribeIntoVolunteering(volunteering.id_voluntariado);
+      if (resp.status === 400) {
+        return await WrongAlert({
+          title: "Error",
+          message: resp.response.data.message,
+        });
+      }
+      return await SuccessAlert({
+        title: "¡Inscripción exitosa!",
+        message: "Esperarás ser aceptado pronto.",
+        timer: 1500,
+        position: "top-right",
+      });
+    } catch (e) {
+      Swal.fire({
+        title: "Error",
+        text: "No fue posible realizar la inscripción.",
+        icon: "error",
+      });
+    } finally {
+      setInscribing(false);
+    }
+  };
 
   const formatDate = (dateString) => {
-    const date = new Date(dateString)
+    const date = new Date(dateString);
     return date.toLocaleDateString("es-ES", {
       day: "2-digit",
       month: "short",
       year: "numeric",
-    })
-  }
+    });
+  };
 
   const formatTime = (dateString) => {
-    const date = new Date(dateString)
+    const date = new Date(dateString);
     return date.toLocaleTimeString("es-ES", {
       hour: "2-digit",
       minute: "2-digit",
-    })
-  }
+    });
+  };
 
   const getStatusColor = (status) => {
     switch (status?.toLowerCase()) {
-      case "pendiente": return "pending"
-      case "activo": return "active"
-      case "completado": return "completed"
-      case "cancelado": return "cancelled"
-      default: return "pending"
+      case "pendiente":
+        return "available";
+      case "activo":
+        return "active";
+      case "completado":
+        return "completed";
+      case "cancelado":
+        return "cancelled";
+      default:
+        return "pending";
     }
-  }
+  };
 
   const truncateText = (text, maxLength) => {
-    if (!text) return ""
-    return text.length > maxLength ? text.substring(0, maxLength) + "..." : text
-  }
+    if (!text) return "";
+    return text.length > maxLength
+      ? text.substring(0, maxLength) + "..."
+      : text;
+  };
 
-  const photoUrl = fotos && fotos.length > 0 ? fotos[0].url : "/volunteering.jpg"
+  const photoUrl =
+    fotos && fotos.length > 0 ? fotos[0].url : "/volunteering.jpg";
 
-  const inscritos = inscripciones?.length || 0
-  const aceptados = participantesAceptados || 0
-  const ocupacionPorcentaje = maxParticipantes ? Math.round((aceptados / maxParticipantes) * 100) : 0
+  const inscritos = inscripciones?.length || 0;
+  const aceptados = participantesAceptados || 0;
+  const ocupacionPorcentaje = maxParticipantes
+    ? Math.round((aceptados / maxParticipantes) * 100)
+    : 0;
 
   // Carousel logic
-  const [index, setIndex] = useState(0)
-  const [isPaused, setIsPaused] = useState(false)
-  const autoplayRef = useRef(null)
-  const FOTO_COUNT = Array.isArray(fotos) ? fotos.length : 0
-  const AUTOPLAY_INTERVAL = 4000 // ms
+  const [index, setIndex] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+  const autoplayRef = useRef(null);
+  const FOTO_COUNT = Array.isArray(fotos) ? fotos.length : 0;
+  const AUTOPLAY_INTERVAL = 4000;
 
   useEffect(() => {
-    // reset index if fotos length changes
-    setIndex((i) => {
-      if (FOTO_COUNT === 0) return 0
-      return i >= FOTO_COUNT ? 0 : i
-    })
-  }, [FOTO_COUNT])
+    setIndex((i) => (FOTO_COUNT === 0 ? 0 : i >= FOTO_COUNT ? 0 : i));
+  }, [FOTO_COUNT]);
 
   useEffect(() => {
-    if (FOTO_COUNT <= 1) return
+    if (FOTO_COUNT <= 1) return;
     if (isPaused) {
       if (autoplayRef.current) {
-        clearInterval(autoplayRef.current)
-        autoplayRef.current = null
+        clearInterval(autoplayRef.current);
+        autoplayRef.current = null;
       }
-      return
+      return;
     }
     autoplayRef.current = setInterval(() => {
-      setIndex((i) => (i + 1) % FOTO_COUNT)
-    }, AUTOPLAY_INTERVAL)
-
+      setIndex((i) => (i + 1) % FOTO_COUNT);
+    }, AUTOPLAY_INTERVAL);
     return () => {
       if (autoplayRef.current) {
-        clearInterval(autoplayRef.current)
-        autoplayRef.current = null
+        clearInterval(autoplayRef.current);
+        autoplayRef.current = null;
       }
-    }
-  }, [FOTO_COUNT, isPaused])
+    };
+  }, [FOTO_COUNT, isPaused]);
 
   const prev = (e) => {
-    e?.stopPropagation()
-    setIndex((i) => (i - 1 + FOTO_COUNT) % FOTO_COUNT)
-  }
+    e?.stopPropagation();
+    setIndex((i) => (i - 1 + FOTO_COUNT) % FOTO_COUNT);
+  };
   const next = (e) => {
-    e?.stopPropagation()
-    setIndex((i) => (i + 1) % FOTO_COUNT)
-  }
-  const goTo = (i) => {
-    setIndex(i)
-  }
+    e?.stopPropagation();
+    setIndex((i) => (i + 1) % FOTO_COUNT);
+  };
+  const goTo = (i) => setIndex(i);
 
   return (
     <div className="volunteering-card">
@@ -120,7 +163,6 @@ function VolunteeringCard({ volunteering, onFocusMap }) {
               alt={`${titulo} - ${index + 1}`}
               className="volunteering-card-main-image"
             />
-
             {FOTO_COUNT > 1 && (
               <>
                 <button
@@ -137,7 +179,6 @@ function VolunteeringCard({ volunteering, onFocusMap }) {
                 >
                   ›
                 </button>
-
                 <div className="volunteering-card-carousel-indicators">
                   {fotos.map((f, i) => (
                     <button
@@ -152,11 +193,8 @@ function VolunteeringCard({ volunteering, onFocusMap }) {
             )}
           </>
         ) : (
-          <>
-            <img src={photoUrl || "/placeholder.svg"} alt={titulo} />
-          </>
+          <img src={photoUrl || "/placeholder.svg"} alt={titulo} />
         )}
-
         <div className="volunteering-card-category-badge">
           {categoria?.nombre}
         </div>
@@ -165,8 +203,16 @@ function VolunteeringCard({ volunteering, onFocusMap }) {
       <div className="volunteering-card-content">
         <div className="volunteering-card-header">
           <h3 className="volunteering-card-title">{titulo}</h3>
-          <span className={`volunteering-card-status volunteering-card-status-${getStatusColor(estado)}`}>
-            {estado?.charAt(0).toUpperCase() + estado?.slice(1).toLowerCase()}
+          <span
+            className={`volunteering-card-status volunteering-card-status-${getStatusColor(
+              estado
+            )}`}
+          >
+            {estado?.toLowerCase() === "pendiente"
+              ? "DISPONIBLE"
+              : estado
+              ? estado.charAt(0).toUpperCase() + estado.slice(1).toLowerCase()
+              : ""}
           </span>
         </div>
 
@@ -174,7 +220,6 @@ function VolunteeringCard({ volunteering, onFocusMap }) {
           {truncateText(descripcion, 100)}
         </p>
 
-        {/* Creator section */}
         <div className="volunteering-card-creator">
           <img
             src={creador?.url_imagen || "/placeholder.svg"}
@@ -192,10 +237,16 @@ function VolunteeringCard({ volunteering, onFocusMap }) {
           </div>
         </div>
 
-        {/* Meta section with date and time */}
         <div className="volunteering-card-meta">
           <div className="volunteering-card-meta-item">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
               <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
               <line x1="16" y1="2" x2="16" y2="6"></line>
               <line x1="8" y1="2" x2="8" y2="6"></line>
@@ -203,24 +254,35 @@ function VolunteeringCard({ volunteering, onFocusMap }) {
             </svg>
             <span>{formatDate(fechaHoraInicio)}</span>
           </div>
-
           <div className="volunteering-card-meta-item">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
               <circle cx="12" cy="12" r="10"></circle>
               <polyline points="12 6 12 12 16 14"></polyline>
             </svg>
             <span>{formatTime(fechaHoraInicio)}</span>
           </div>
-
           <div className="volunteering-card-meta-item">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
               <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"></path>
             </svg>
             <span>{horas} horas</span>
           </div>
         </div>
 
-        {/* Participants stats */}
         <div className="volunteering-card-participants-stats">
           <div className="volunteering-card-stat">
             <span className="volunteering-card-stat-number">{inscritos}</span>
@@ -231,7 +293,9 @@ function VolunteeringCard({ volunteering, onFocusMap }) {
             <span className="volunteering-card-stat-label">Aceptados</span>
           </div>
           <div className="volunteering-card-stat">
-            <span className="volunteering-card-stat-number">{maxParticipantes}</span>
+            <span className="volunteering-card-stat-number">
+              {maxParticipantes}
+            </span>
             <span className="volunteering-card-stat-label">Cupos</span>
           </div>
         </div>
@@ -243,14 +307,31 @@ function VolunteeringCard({ volunteering, onFocusMap }) {
               style={{ width: `${ocupacionPorcentaje}%` }}
             ></div>
           </div>
-          <span className="volunteering-card-occupancy-text">{ocupacionPorcentaje}% ocupado</span>
+          <span className="volunteering-card-occupancy-text">
+            {ocupacionPorcentaje}% ocupado
+          </span>
         </div>
+
         <div className="volunteering-card-footer">
-          <button className="volunteering-card-inscribe-btn">
-            Inscribete ahora
+          <button
+            className="volunteering-card-inscribe-btn"
+            onClick={handleInscribe}
+            disabled={inscribing}
+          >
+            {inscribing ? "Inscribiendo..." : "Inscríbete ahora"}
           </button>
-          <button className="volunteering-card-location-btn" onClick={() => onFocusMap?.()}>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <button
+            className="volunteering-card-location-btn"
+            onClick={() => onFocusMap?.()}
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
               <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z"></path>
               <circle cx="12" cy="10" r="3"></circle>
             </svg>
@@ -259,8 +340,7 @@ function VolunteeringCard({ volunteering, onFocusMap }) {
         </div>
       </div>
     </div>
-  )
+  );
 }
 
-export default VolunteeringCard
-// ...existing code...
+export default VolunteeringCard;

--- a/frontend/src/layouts/HomeVolunteerLayout/HomeVolunteerLayout.jsx
+++ b/frontend/src/layouts/HomeVolunteerLayout/HomeVolunteerLayout.jsx
@@ -1,67 +1,41 @@
-import React, { useEffect, useState, useRef, useCallback } from "react";
+import React, { useState, useRef, useCallback } from "react";
 import "./HomeVolunteerLayout.css";
-import { GetVolunteerings } from "../../services/volunteering/VolunteeringService";
-import VolunteeringCard from "../../components/VolunteeringCard/VolunteeringCard";
 import VolunteeringMapLayout from "../VolunteeringMapLayout/VolunteeringMapLayout";
 import SearchVolunteerings from "../../components/SearchVolunteerings/SearchVolunteerings";
+import VolunteeringCardLayout from "../VolunteeringCardLayout/VolunteeringCardLayout";
 
 function HomeVolunteerLayout() {
-  const [volunteerings, setVolunteerings] = useState([]);
-  const [loading, setLoading] = useState(false);
   const [filters, setFilters] = useState({});
+  const [volunteeringsForMap, setVolunteeringsForMap] = useState([]);
   const mapApiRef = useRef(null);
-
-  const fetchVolunteerings = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = await GetVolunteerings(filters);
-      setVolunteerings(Array.isArray(data) ? data : []);
-    } catch (e) {
-      console.error("Error cargando voluntariados", e);
-      setVolunteerings([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [filters]);
-
-  useEffect(() => {
-    fetchVolunteerings();
-  }, [fetchVolunteerings]);
 
   const handleApplyFilters = (newFilters) => {
     setFilters(newFilters || {});
   };
 
-  const handleFocusOnMap = (ubicacion, zoom = 15) => {
-    if (!ubicacion) return;
-    const lat = parseFloat(ubicacion.latitud);
-    const lng = parseFloat(ubicacion.longitud);
-    if (mapApiRef.current?.focusLocation) {
-      mapApiRef.current.focusLocation(lat, lng, zoom);
-    }
-  };
+  // Memo para evitar cambiar la referencia y provocar refetch en el hijo
+  const handleVolunteeringsChange = useCallback((list) => {
+    setVolunteeringsForMap(Array.isArray(list) ? list : []);
+  }, []);
 
   return (
     <div className="home-volunteer-layout">
       <h1 className="home-volunteer-layout-title">
         Ubica los próximos eventos y elige dónde quieres aportar tu tiempo.
       </h1>
-      <VolunteeringMapLayout volunteerings={volunteerings} mapApiRef={mapApiRef} />
+
+      <VolunteeringMapLayout volunteerings={volunteeringsForMap} mapApiRef={mapApiRef} />
+
       <h1 className="home-volunteer-layout-title">Filtrar eventos</h1>
       <SearchVolunteerings onApplyFilters={handleApplyFilters} />
+
       <h1 className="home-volunteer-layout-title">Eventos disponibles</h1>
-      {loading && <p>Cargando...</p>}
-      {volunteerings?.length > 0 ? (
-        volunteerings.map((volunteering) => (
-          <VolunteeringCard
-            key={volunteering.id_voluntariado}
-            volunteering={volunteering}
-            onFocusMap={() => handleFocusOnMap(volunteering.ubicacion, 15)}
-          />
-        ))
-      ) : (
-        !loading && <p>No se encontraron eventos.</p>
-      )}
+
+      <VolunteeringCardLayout
+        filters={filters}
+        mapApiRef={mapApiRef}
+        onVolunteeringsChange={handleVolunteeringsChange}
+      />
     </div>
   );
 }

--- a/frontend/src/layouts/VolunteeringCardLayout/VolunteeringCardLayout.css
+++ b/frontend/src/layouts/VolunteeringCardLayout/VolunteeringCardLayout.css
@@ -1,0 +1,244 @@
+/* Main Container */
+.volunteering-card-layout {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-sizing: border-box;
+  align-items: center;
+  margin: 0 auto;
+  padding: 1rem 0.5rem;
+}
+
+/* Loading and Empty States */
+.volunteering-card-layout-loading,
+.volunteering-card-layout-empty {
+  width: 100%;
+  text-align: center;
+  color: #007aff;
+  padding: 2rem 1rem;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+[data-theme="dark"] .volunteering-card-layout-loading,
+[data-theme="dark"] .volunteering-card-layout-empty {
+  color: #5ac8fa;
+}
+
+/* Pagination Container */
+.volunteering-card-layout-pagination {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem 1.5rem;
+  max-width: 600px;
+  width: 100%;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(30px) saturate(180%);
+  -webkit-backdrop-filter: blur(30px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1),
+              0 0 0 1px rgba(255, 255, 255, 0.2) inset;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+[data-theme="dark"] .volunteering-card-layout-pagination {
+  background: rgba(42, 42, 42, 0.9);
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3),
+              0 0 0 1px rgba(255, 255, 255, 0.1) inset;
+}
+
+.volunteering-card-layout-pagination:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15),
+              0 0 0 1px rgba(255, 255, 255, 0.25) inset;
+}
+
+[data-theme="dark"] .volunteering-card-layout-pagination:hover {
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4),
+              0 0 0 1px rgba(255, 255, 255, 0.15) inset;
+}
+
+/* Pagination Buttons */
+.volunteering-card-layout-pagination-btn {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba(0, 122, 255, 0.1) 0%, rgba(0, 122, 255, 0.05) 100%);
+  border: 1px solid rgba(0, 122, 255, 0.2);
+  border-radius: 10px;
+  color: #007aff;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+[data-theme="dark"] .volunteering-card-layout-pagination-btn {
+  background: linear-gradient(135deg, rgba(0, 122, 255, 0.15) 0%, rgba(0, 122, 255, 0.08) 100%);
+  border-color: rgba(0, 122, 255, 0.3);
+  color: #5ac8fa;
+}
+
+.volunteering-card-layout-pagination-btn:hover:not(:disabled) {
+  background: linear-gradient(135deg, rgba(0, 122, 255, 0.2) 0%, rgba(0, 122, 255, 0.1) 100%);
+  border-color: rgba(0, 122, 255, 0.4);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 122, 255, 0.2);
+}
+
+[data-theme="dark"] .volunteering-card-layout-pagination-btn:hover:not(:disabled) {
+  background: linear-gradient(135deg, rgba(0, 122, 255, 0.25) 0%, rgba(0, 122, 255, 0.15) 100%);
+  border-color: rgba(0, 122, 255, 0.4);
+  box-shadow: 0 4px 12px rgba(0, 122, 255, 0.3);
+}
+
+.volunteering-card-layout-pagination-btn:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.volunteering-card-layout-pagination-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Page Numbers Container */
+.volunteering-card-layout-pagination-numbers {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* Page Number Buttons */
+.volunteering-card-layout-pagination-number {
+  min-width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.05);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  color: #525252;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+[data-theme="dark"] .volunteering-card-layout-pagination-number {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.15);
+  color: #d4d4d4;
+}
+
+.volunteering-card-layout-pagination-number:hover:not(.volunteering-card-layout-pagination-number-active) {
+  background: rgba(0, 122, 255, 0.1);
+  border-color: rgba(0, 122, 255, 0.2);
+  color: #007aff;
+  transform: translateY(-1px);
+}
+
+[data-theme="dark"] .volunteering-card-layout-pagination-number:hover:not(.volunteering-card-layout-pagination-number-active) {
+  background: rgba(0, 122, 255, 0.15);
+  border-color: rgba(0, 122, 255, 0.3);
+  color: #5ac8fa;
+}
+
+.volunteering-card-layout-pagination-number-active {
+  background: linear-gradient(135deg, #007aff 0%, #0051d5 100%);
+  border-color: rgba(0, 122, 255, 0.4);
+  color: white;
+  font-weight: 600;
+  box-shadow: 0 4px 12px rgba(0, 122, 255, 0.3);
+}
+
+.volunteering-card-layout-pagination-number-active:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 122, 255, 0.4);
+}
+
+/* Pagination Info */
+.volunteering-card-layout-pagination-info {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #6b6b6b;
+  margin-left: 0.5rem;
+  padding-left: 0.75rem;
+  border-left: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="dark"] .volunteering-card-layout-pagination-info {
+  color: #a0a0a0;
+  border-left-color: rgba(255, 255, 255, 0.15);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .volunteering-card-layout {
+    gap: 1.25rem;
+    padding: 0.75rem 0.5rem;
+  }
+
+  .volunteering-card-layout-pagination {
+    padding: 1rem 1.25rem;
+    gap: 0.6rem;
+  }
+
+  .volunteering-card-layout-pagination-btn {
+    width: 36px;
+    height: 36px;
+  }
+
+  .volunteering-card-layout-pagination-number {
+    min-width: 32px;
+    height: 32px;
+    font-size: 0.85rem;
+  }
+
+  .volunteering-card-layout-pagination-info {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .volunteering-card-layout {
+    gap: 1rem;
+    padding: 0.5rem 0.25rem;
+  }
+
+  .volunteering-card-layout-pagination {
+    padding: 0.875rem 1rem;
+    gap: 0.5rem;
+    width: 100%;
+    max-width: none;
+  }
+
+  .volunteering-card-layout-pagination-btn {
+    width: 32px;
+    height: 32px;
+  }
+
+  .volunteering-card-layout-pagination-btn svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  .volunteering-card-layout-pagination-numbers {
+    gap: 0.3rem;
+  }
+
+  .volunteering-card-layout-pagination-number {
+    min-width: 28px;
+    height: 28px;
+    font-size: 0.8rem;
+  }
+}

--- a/frontend/src/layouts/VolunteeringCardLayout/VolunteeringCardLayout.jsx
+++ b/frontend/src/layouts/VolunteeringCardLayout/VolunteeringCardLayout.jsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useRef, useState } from "react";
+import "./VolunteeringCardLayout.css";
+import { GetVolunteerings } from "../../services/volunteering/VolunteeringService";
+import VolunteeringCard from "../../components/VolunteeringCard/VolunteeringCard";
+
+export default function VolunteeringCardLayout({ filters = {}, mapApiRef = null, onVolunteeringsChange = () => {} }) {
+  const [volunteerings, setVolunteerings] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [page, setPage] = useState(1);
+  const itemsPerPage = 2;
+
+  const onChangeRef = useRef(onVolunteeringsChange);
+  useEffect(() => {
+    onChangeRef.current = onVolunteeringsChange;
+  }, [onVolunteeringsChange]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const data = await GetVolunteerings(filters);
+        const list = Array.isArray(data) ? data : [];
+        if (!cancelled) {
+          setVolunteerings(list);
+          setPage(1);
+          onChangeRef.current?.(list);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          console.error("Error cargando voluntariados", e);
+          setVolunteerings([]);
+          setPage(1);
+          onChangeRef.current?.([]);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchData();
+    return () => {
+      cancelled = true;
+    };
+  }, [filters]);
+
+  const totalItems = volunteerings.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / itemsPerPage));
+  const currentSlice = volunteerings.slice((page - 1) * itemsPerPage, page * itemsPerPage);
+
+  const goTo = (p) => setPage(Math.min(Math.max(1, p), totalPages));
+
+  const handleFocusOnMap = (ubicacion, zoom = 15) => {
+    if (!ubicacion) return;
+    const lat = parseFloat(ubicacion.latitud);
+    const lng = parseFloat(ubicacion.longitud);
+    if (mapApiRef?.current?.focusLocation) {
+      mapApiRef.current.focusLocation(lat, lng, zoom);
+    }
+  };
+
+  return (
+    <section className="volunteering-card-layout">
+      {loading && <p className="volunteering-card-layout-loading">Cargando...</p>}
+      {!loading && currentSlice.length === 0 && <p className="volunteering-card-layout-empty">No se encontraron eventos.</p>}
+      {!loading &&
+        currentSlice.map((v) => (
+          <VolunteeringCard
+            key={v.id_voluntariado}
+            volunteering={v}
+            onFocusMap={() => handleFocusOnMap(v.ubicacion, 20)}
+          />
+        ))}
+
+      {totalPages > 1 && (
+        <nav className="volunteering-card-layout-pagination" aria-label="Paginación de voluntariados">
+          <button 
+            className="volunteering-card-layout-pagination-btn volunteering-card-layout-pagination-prev" 
+            onClick={() => goTo(page - 1)} 
+            disabled={page <= 1}
+            aria-label="Página anterior"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <polyline points="15 18 9 12 15 6"></polyline>
+            </svg>
+          </button>
+
+          <div className="volunteering-card-layout-pagination-numbers">
+            {Array.from({ length: totalPages }).map((_, i) => {
+              const p = i + 1;
+              return (
+                <button
+                  key={p}
+                  className={`volunteering-card-layout-pagination-number ${p === page ? "volunteering-card-layout-pagination-number-active" : ""}`}
+                  onClick={() => goTo(p)}
+                  aria-label={`Ir a página ${p}`}
+                  aria-current={p === page ? "page" : undefined}
+                >
+                  {p}
+                </button>
+              );
+            })}
+          </div>
+
+          <button 
+            className="volunteering-card-layout-pagination-btn volunteering-card-layout-pagination-next" 
+            onClick={() => goTo(page + 1)} 
+            disabled={page >= totalPages}
+            aria-label="Página siguiente"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </button>
+
+          <span className="volunteering-card-layout-pagination-info">
+            {page} / {totalPages}
+          </span>
+        </nav>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/services/map/MapService.jsx
+++ b/frontend/src/services/map/MapService.jsx
@@ -1,5 +1,3 @@
-import { useRef } from "react";
-
 const defaultOpts = {
   defaultZoom: 18,
   scrollIntoViewOptions: { behavior: "smooth", block: "center" },

--- a/frontend/src/services/volunteering/VolunteeringService.jsx
+++ b/frontend/src/services/volunteering/VolunteeringService.jsx
@@ -41,7 +41,16 @@ export const GetVolunteerings = async (filters = {}) => {
   }
 };
 
-// Compatibilidad con llamadas previas que usaban GetAllVolunteerings
 export const GetAllVolunteerings = async () => {
   return await GetVolunteerings();
 };
+
+export const InscribeIntoVolunteering = async (id_voluntariado) =>{
+  try{
+    const response = await api.post("/inscripciones/"+id_voluntariado);
+    console.log(response)
+    return response.data;
+  }catch(error){
+    return error;
+  }
+}


### PR DESCRIPTION
# Descripción
Se separó la lógica de obtención y filtrado de voluntariados desde `HomeVolunteerLayout` hacia `VolunteeringCardLayout`. Se agregó paginación (2 ítems por página), se evitó el bucle de recarga memorizando el callback, se renombró el estado `pendiente` a `DISPONIBLE` (card y modal), y se implementó flujo de inscripción con confirmación y feedback (SweetAlert). También se ajustó el enfoque del mapa desde las cards y se ocultó la paginación cuando solo existe una página.

### Cambios principales
- Nuevo `VolunteeringCardLayout` con fetch, filtros y paginación.  
- Reset de página al cambiar filtros.  
- Callback memoizado para evitar refetch infinito.  
- Estado visual DISPONIBLE para “pendiente”.  
- Confirmación antes de inscribir y manejo de errores.  
- Paginación con diseño glass coherente al resto.  
- Ocultación de paginación si `totalPages === 1`.

# Fixes
Closes #197


# Screenshots o videos 
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/94020de5-2ea5-43f3-8550-32cc2e64e2a7" />
